### PR TITLE
Add MultiPV search, time manager, and UCI option handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ add_executable(nikolachess
     src/see.cpp
     src/polyglot.cpp
     src/distributed.cpp
+    # v20 additions
+    src/engine_options.cpp
+    src/time_manager.cpp
+    src/pv.cpp
+    src/multipv_search.cpp
+    src/uci_extensions.cpp
 )
 
 # Enable CUDA separable compilation for proper device linking.

--- a/src/engine_options.cpp
+++ b/src/engine_options.cpp
@@ -1,0 +1,77 @@
+#include "engine_options.h"
+#include <iostream>
+#include <algorithm>
+#include <cctype>
+
+namespace nikola {
+
+static EngineOptions G;
+
+EngineOptions& opts() { return G; }
+
+static inline std::string lower(std::string s){
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c){ return std::tolower(c); });
+    return s;
+}
+
+void set_option_from_tokens(const std::vector<std::string>& t) {
+    // Expect sequence: setoption name <NAME> [value <VAL>]
+    auto itn = std::find(t.begin(), t.end(), "name");
+    if (itn == t.end()) return;
+    std::string name;
+    std::string value;
+    auto itv = std::find(t.begin(), t.end(), "value");
+    if (itv != t.end()) {
+        name = lower(std::string(itn+1, itv));
+        value = std::string(itv+1, t.end());
+    } else {
+        name = lower(std::string(itn+1, t.end()));
+        value = "true"; // toggles
+    }
+
+    if (name == "multipv") {
+        int v = std::clamp(std::stoi(value), 1, 8);
+        G.MultiPV = v;
+    } else if (name == "limitstrength") {
+        std::string v = lower(value);
+        G.LimitStrength = (v == "true" || v == "1" || v == "on" || v == "yes");
+    } else if (name == "strength") {
+        int v = std::clamp(std::stoi(value), 0, 20);
+        G.Strength = v;
+    } else if (name == "syzygypath") {
+        G.SyzygyPath = value;
+    } else if (name == "uci_showwdl") {
+        std::string v = lower(value);
+        G.UCI_ShowWDL = (v == "true" || v == "1" || v == "on" || v == "yes");
+    } else if (name == "hash") {
+        int v = std::clamp(std::stoi(value), 4, 4096);
+        G.HashMB = v;
+    } else if (name == "moveoverhead") {
+        int v = std::clamp(std::stoi(value), 0, 1000);
+        G.MoveOverhead = v;
+    } else if (name == "threads") {
+        int v = std::clamp(std::stoi(value), 1, 128);
+        G.Threads = v;
+    }
+}
+
+void print_id_and_options() {
+    std::cout << "id name SupercomputerChessEngine v20" << std::endl;
+    std::cout << "id author CPUTER Inc." << std::endl;
+    std::cout << "option name MultiPV type spin default 1 min 1 max 8" << std::endl;
+    std::cout << "option name LimitStrength type check default false" << std::endl;
+    std::cout << "option name Strength type spin default 20 min 0 max 20" << std::endl;
+    std::cout << "option name SyzygyPath type string default" << std::endl;
+    std::cout << "option name UCI_ShowWDL type check default false" << std::endl;
+    std::cout << "option name Hash type spin default 64 min 4 max 4096" << std::endl;
+    std::cout << "option name MoveOverhead type spin default 50 min 0 max 1000" << std::endl;
+    std::cout << "option name Threads type spin default 1 min 1 max 128" << std::endl;
+    std::cout << "uciok" << std::endl;
+}
+
+void on_isready() {
+    // If you want to lazy-open Syzygy here, do it (calls in multipv_search will also probe).
+    std::cout << "readyok" << std::endl;
+}
+
+} // namespace nikola

--- a/src/engine_options.h
+++ b/src/engine_options.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <string>
+#include <vector>
+
+namespace nikola {
+
+struct EngineOptions {
+    int MultiPV = 1;           // 1..8
+    bool LimitStrength = false;
+    int Strength = 20;         // 0..20 → caps depth = 1 + Strength
+    std::string SyzygyPath;    // WDL+DTZ path (optional)
+    bool UCI_ShowWDL = false;
+    int HashMB = 64;           // TT soft budget
+    int MoveOverhead = 50;     // ms
+    int Threads = 1;           // placeholder (root‑stable only in this patch)
+};
+
+// Global accessor (simple singleton for UCI layer)
+EngineOptions& opts();
+
+// Utility: parse tokens like [name, MultiPV, value, 3, ...]
+void set_option_from_tokens(const std::vector<std::string>& tokens);
+
+// Print ID + options block
+void print_id_and_options();
+
+// isready hook (e.g., open tablebases lazily)
+void on_isready();
+
+} // namespace nikola

--- a/src/multipv_search.cpp
+++ b/src/multipv_search.cpp
@@ -1,0 +1,136 @@
+#include "multipv_search.h"
+#include "engine_options.h"
+#include "time_manager.h"
+#include "pv.h"
+#include "tt_sharded.h"
+#include "tablebase.h"
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+
+namespace nikola {
+
+static constexpr int MATE = 30000;
+static constexpr int INF  = 32000;
+
+static uint64_t key64(const Board& b) {
+    uint64_t k = 0x9E3779B97F4A7C15ULL;
+    for (int r=0;r<8;++r){
+        for (int c=0;c<8;++c){
+            int v = b.squares[r][c];
+            k ^= (uint64_t)((v & 0xFF) + 0x9E) + 0x9E3779B97F4A7C15ULL + (k<<6) + (k>>2);
+        }
+    }
+    if (b.whiteToMove) k ^= 0xF00DFACEB00B5ULL;
+    return k;
+}
+
+static inline bool isCapture(const Move& m){ return m.captured != EMPTY; }
+
+// Lightweight alpha-beta that writes TT bestMove at each node for PV chaining.
+static int alphabeta(Board& b, int depth, int alpha, int beta, int ply) {
+    if (depth <= 0) {
+        return evaluateBoardCPU(b);
+    }
+
+    int wdl = probeWDL(b); // existing semantics: 1 win, 0 draw, -1 loss, 2 unknown
+    if (wdl != 2) {
+        if (wdl == 1) return MATE - ply;
+        if (wdl == -1) return -MATE + ply;
+        return 0;
+    }
+
+    auto moves = generateMoves(b);
+    if (moves.empty()) return 0; // stalemate/checkmate handled by eval in demo
+
+    // Basic ordering: captures first
+    std::stable_sort(moves.begin(), moves.end(), [&](const Move& a, const Move& c){
+        return isCapture(a) && !isCapture(c);
+    });
+
+    int bestScore = -INF;
+    Move bestMove = moves[0];
+    for (const auto& m : moves) {
+        Board nb = makeMove(b, m);
+        int sc = -alphabeta(nb, depth-1, -beta, -alpha, ply+1);
+        if (sc > bestScore) { bestScore = sc; bestMove = m; }
+        if (sc > alpha) alpha = sc;
+        if (alpha >= beta) break;
+    }
+
+    // store into TT for PV extraction
+    TTEntry e; e.depth = depth; e.score = bestScore; e.flag = 0; e.bestMove = bestMove;
+    tt_store(key64(b), e);
+    return bestScore;
+}
+
+std::vector<RootResult> search_multipv(Board root, int N, int depthCap, int timeBudgetMs) {
+    EngineOptions& o = opts();
+    N = std::max(1, std::min(N, 8));
+
+    // Strength cap
+    if (o.LimitStrength) {
+        int cap = 1 + o.Strength;
+        if (depthCap <= 0 || depthCap > cap) depthCap = cap;
+    }
+
+    auto legal = generateMoves(root);
+    if (legal.empty()) return {};
+
+    // Order root: captures first
+    std::stable_sort(legal.begin(), legal.end(), [&](const Move& a, const Move& c){
+        return isCapture(a) && !isCapture(c);
+    });
+
+    auto t0 = std::chrono::steady_clock::now();
+    auto deadline = (timeBudgetMs>0) ? (t0 + std::chrono::milliseconds(timeBudgetMs)) : std::chrono::steady_clock::time_point::max();
+
+    std::vector<RootResult> out;
+    out.reserve(N);
+
+    for (int slot=0; slot<N && slot < (int)legal.size(); ++slot) {
+        const Move cand = legal[slot];
+        int bestScore = -INF;
+        int lastScore = 0;
+        Move chosen = cand;
+        int targetDepth = (depthCap>0)? depthCap : 64;
+
+        int alpha = -INF, beta = INF; // aspiration init
+        int window = 50;
+
+        for (int d=1; d<=targetDepth; ++d) {
+            // aspiration around lastScore after first few depths
+            if (d > 2) { alpha = lastScore - window; beta = lastScore + window; }
+            Board b = makeMove(root, cand);
+            int sc = alphabeta(b, d-1, alpha, beta, 1);
+            // widen on fail
+            if (sc <= alpha) { window *= 2; --d; continue; }
+            if (sc >= beta)  { window *= 2; --d; continue; }
+            lastScore = sc; bestScore = sc; chosen = cand;
+
+            if (std::chrono::steady_clock::now() > deadline) break;
+        }
+
+        // panic extension: one more depth if time remains
+        if (std::chrono::steady_clock::now() < deadline && targetDepth >= 6) {
+            Board b = makeMove(root, cand);
+            int sc = alphabeta(b, std::min(targetDepth,(depthCap>0?depthCap:targetDepth))+1 - 1, -INF, INF, 1);
+            if (std::abs(sc) < INF) bestScore = sc;
+        }
+
+        // build PV via TT chaining
+        std::vector<Move> pv = extract_pv(root, 60);
+        if (pv.empty()) pv.push_back(chosen);
+
+        out.push_back(RootResult{bestScore, chosen, pv});
+
+        if (std::chrono::steady_clock::now() > deadline) break;
+    }
+
+    // sort best-first by score
+    std::stable_sort(out.begin(), out.end(), [](const RootResult& A, const RootResult& B){ return A.scoreCentipawns > B.scoreCentipawns; });
+    if ((int)out.size() > N) out.resize(N);
+    return out;
+}
+
+} // namespace nikola

--- a/src/multipv_search.h
+++ b/src/multipv_search.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <vector>
+#include <utility>
+#include <string>
+#include "board.h"
+
+namespace nikola {
+
+struct RootResult {
+    int scoreCentipawns; // use mate scores as large cp (e.g., 30000)
+    Move firstMove;      // root move for this slot
+    std::vector<Move> pv;// full PV moves
+};
+
+// Run MultiPV root search with aspiration + panic, respecting time budget.
+// If depthCap <= 0, auto‑depth. Returns up to N results ordered best‑first.
+std::vector<RootResult> search_multipv(Board root,
+                                       int N,
+                                       int depthCap,
+                                       int timeBudgetMs);
+
+}

--- a/src/pv.cpp
+++ b/src/pv.cpp
@@ -1,0 +1,51 @@
+#include "pv.h"
+#include "tt_sharded.h"
+#include "board.h"
+#include <sstream>
+#include <iomanip>
+#include <cstdint>
+
+namespace nikola {
+
+// Simple 64-bit key for TT/PV purposes: mix piece squares and side to move.
+static uint64_t key64(const Board& b) {
+    uint64_t k = 0x9E3779B97F4A7C15ULL;
+    for (int r=0;r<8;++r){
+        for (int c=0;c<8;++c){
+            int v = b.squares[r][c];
+            k ^= (uint64_t)((v & 0xFF) + 0x9E) + 0x9E3779B97F4A7C15ULL + (k<<6) + (k>>2);
+        }
+    }
+    if (b.whiteToMove) k ^= 0xF00DFACEB00B5ULL;
+    return k;
+}
+
+std::vector<Move> extract_pv(const Board& root, int maxLen) {
+    std::vector<Move> pv;
+    Board b = root;
+    for (int i=0;i<maxLen;++i) {
+        auto k = key64(b);
+        TTEntry e;
+        if (!tt_lookup(k, e)) break;
+        if (e.bestMove.fromRow == e.bestMove.toRow && e.bestMove.fromCol == e.bestMove.toCol) break;
+        pv.push_back(e.bestMove);
+        b = makeMove(b, e.bestMove);
+    }
+    return pv;
+}
+
+static char fileChar(int c){ return char('a'+c); }
+static char rankChar(int r){ return char('1'+r); }
+
+std::string move_to_uci(const Board& b, const Move& m) {
+    (void)b; // if you later need promotion symbol, extend Move
+    std::string s;
+    s.push_back(fileChar(m.fromCol));
+    s.push_back(rankChar(m.fromRow));
+    s.push_back(fileChar(m.toCol));
+    s.push_back(rankChar(m.toRow));
+    // if (m.promotedTo) s.push_back(toLower(pieceChar(m.promotedTo)));
+    return s;
+}
+
+} // namespace nikola

--- a/src/pv.h
+++ b/src/pv.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <vector>
+#include <string>
+#include "board.h"
+
+namespace nikola {
+
+// Extract PV via TT chaining starting from root board with first move already chosen.
+std::vector<Move> extract_pv(const Board& root, int maxLen=60);
+
+// Turn a Move into UCI string like e2e4 (promotion handled as e7e8q).
+std::string move_to_uci(const Board& b, const Move& m);
+
+} // namespace nikola

--- a/src/time_manager.cpp
+++ b/src/time_manager.cpp
@@ -1,0 +1,25 @@
+#include "time_manager.h"
+#include <algorithm>
+
+namespace nikola {
+
+int compute_time_budget(const Board&, bool whiteToMove,
+                        int wtime, int btime, int winc, int binc,
+                        int movestogo, int overhead_ms, double safety) {
+    if (wtime < 0 || btime < 0) return -1; // infinite
+    int remain = whiteToMove ? wtime : btime;
+    int inc    = whiteToMove ? winc  : binc;
+
+    long long per = 0;
+    if (movestogo > 0) {
+        per = remain / std::max(1, movestogo);
+    } else {
+        per = (long long)(remain * 0.02) + inc; // 2% of remaining + increment
+    }
+    per -= overhead_ms;
+    per = (long long)(per * (1.0 - safety));
+    if (per < 1) per = 1;
+    return (int)per;
+}
+
+}

--- a/src/time_manager.h
+++ b/src/time_manager.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "board.h"
+
+namespace nikola {
+
+// Returns ms budget for this move, or -1 for infinite (no clocks).
+int compute_time_budget(const Board& b, bool whiteToMove,
+                        int wtime, int btime, int winc, int binc,
+                        int movestogo, int overhead_ms, double safety=0.10);
+
+}

--- a/src/uci_extensions.cpp
+++ b/src/uci_extensions.cpp
@@ -1,0 +1,81 @@
+#include "uci_extensions.h"
+#include "engine_options.h"
+#include "time_manager.h"
+#include "multipv_search.h"
+#include "pv.h"
+#include "tablebase.h"
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+
+namespace nikola {
+
+void uci_print_id_and_options(){ print_id_and_options(); }
+void uci_isready(){ on_isready(); }
+void uci_setoption(const std::vector<std::string>& tokens){ set_option_from_tokens(tokens); }
+
+static int to_i(const std::vector<std::string>& t, const char* key, int def=-1){
+    for (size_t i=0;i+1<t.size();++i){ if (t[i]==key) return std::stoi(t[i+1]); }
+    return def;
+}
+
+void uci_go(const Board& current, const std::vector<std::string>& tokens) {
+    EngineOptions& o = opts();
+
+    int depth = to_i(tokens, "depth", -1);
+    int wtime = to_i(tokens, "wtime", -1);
+    int btime = to_i(tokens, "btime", -1);
+    int winc  = to_i(tokens, "winc", 0);
+    int binc  = to_i(tokens, "binc", 0);
+    int mtg   = to_i(tokens, "movestogo", 0);
+
+    if (o.LimitStrength) {
+        int cap = 1 + o.Strength;
+        if (depth < 0 || depth > cap) depth = cap;
+    }
+
+    // compute budget
+    int budget = compute_time_budget(current, current.whiteToMove, wtime, btime, winc, binc, mtg, o.MoveOverhead, 0.10);
+
+    // Run root MultiPV
+    auto results = search_multipv(current, std::max(1,o.MultiPV), depth, budget);
+
+    // Emit info lines
+    for (size_t i=0; i<results.size(); ++i) {
+        const auto& R = results[i];
+        std::ostringstream line;
+        line << "info multipv " << (i+1) << ' ';
+        if (std::abs(R.scoreCentipawns) > 29000) {
+            int mate_in = (30000 - std::abs(R.scoreCentipawns) + 1)/2;
+            if (R.scoreCentipawns < 0) mate_in = -mate_in;
+            line << "score mate " << mate_in << ' ';
+        } else {
+            line << "score cp " << R.scoreCentipawns << ' ';
+        }
+        // optional WDL (root)
+        if (o.UCI_ShowWDL) {
+            int wdl = probeWDL(current); // existing semantics: 1 win, 0 draw, -1 loss, 2 unknown
+            if (wdl != 2) {
+                int win=0,draw=0,loss=0;
+                if (wdl==1) win=1000; else if (wdl==0) draw=1000; else loss=1000;
+                line << "wdl " << win << ',' << draw << ',' << loss << ' ';
+            }
+        }
+        line << "pv";
+        int count = 0;
+        for (const auto& m : R.pv) {
+            line << ' ' << move_to_uci(current, m);
+            if (++count >= 60) break;
+        }
+        std::cout << line.str() << std::endl;
+    }
+
+    // bestmove
+    if (!results.empty()) {
+        std::cout << "bestmove " << move_to_uci(current, results[0].firstMove) << std::endl;
+    } else {
+        std::cout << "bestmove 0000" << std::endl;
+    }
+}
+
+} // namespace nikola

--- a/src/uci_extensions.h
+++ b/src/uci_extensions.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <vector>
+#include <string>
+#include "board.h"
+
+namespace nikola {
+
+void uci_print_id_and_options();
+void uci_isready();
+void uci_setoption(const std::vector<std::string>& tokens);
+
+// Handles `go ...`: parses clocks/depth, computes budget, runs MultiPV, prints
+// `info multipv N score cp|mate ... pv <moves>` lines and `bestmove`.
+void uci_go(const Board& current, const std::vector<std::string>& tokens);
+
+}


### PR DESCRIPTION
## Summary
- add central engine options storage with MultiPV, strength limiting, and move overhead support
- implement time manager, PV reconstruction, and root multi-PV search with aspiration windows
- extend UCI layer to print new options, handle setoption, and run MultiPV search from `go`

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_b_689b865f08a4832a96dc743560de9705