### PR TITLE
Make CUDA optional and fix compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,34 @@
 cmake_minimum_required(VERSION 3.12)
-project(NikolaChess LANGUAGES CXX CUDA)
+project(NikolaChess LANGUAGES CXX)
 
-# Set C++ standard and CUDA settings.  The engine is written in modern C++
-# with separate CUDA kernels for evaluation.  Enabling separable
-# compilation instructs CMake to perform the necessary GPU linking for
-# objects compiled with nvcc.
+# Attempt to enable CUDA if available. The engine can operate purely on
+# the CPU, so lack of a CUDA toolkit should not be a hard error.
+find_package(CUDAToolkit)
+if(CUDAToolkit_FOUND)
+    enable_language(CUDA)
+    set(NIKOLA_HAS_CUDA TRUE)
+else()
+    set(NIKOLA_HAS_CUDA FALSE)
+    message(WARNING "CUDA toolkit not found – building without GPU support")
+endif()
 
+# Set C++ standard.
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Add the executable target for the engine.  Source files are split
-# between C++ and CUDA.  Header only files are included automatically.
-add_executable(nikolachess
+# Common sources.
+set(NIKOLA_SOURCES
     src/main.cpp
     src/board.h
     src/board.cpp
     src/move_generation.cu
-    src/evaluate.cu
     src/search.cpp
     src/perft.cpp
-        src/gpu_eval.cpp
-        src/uci.cpp
+    src/gpu_eval.cpp
+    src/uci.cpp
     src/micro_batcher.cpp
     src/tablebase.cpp
+    src/rules.cpp
     src/pgn_logger.cpp
     src/san.cpp
     src/see.cpp
@@ -33,22 +39,33 @@ add_executable(nikolachess
     src/time_manager.cpp
     src/pv.cpp
     src/multipv_search.cpp
-    src/uci_extensions.cpp
-)
+    src/uci_extensions.cpp)
 
-# Enable CUDA separable compilation for proper device linking.
-set_target_properties(nikolachess PROPERTIES
-    CUDA_SEPARABLE_COMPILATION ON
-    CUDA_ARCHITECTURES 70 # Target compute capability 7.0 by default
-)
+# GPU-specific sources or fallbacks.
+if(NIKOLA_HAS_CUDA)
+    list(APPEND NIKOLA_SOURCES src/evaluate.cu)
+    # Treat CUDA files properly and enable device linking.
+    set_source_files_properties(src/move_generation.cu src/evaluate.cu PROPERTIES LANGUAGE CUDA)
+else()
+    # Build move generation as plain C++ and use a CPU stub for evaluation.
+    set_source_files_properties(src/move_generation.cu PROPERTIES LANGUAGE CXX COMPILE_FLAGS "-x c++")
+    list(APPEND NIKOLA_SOURCES src/evaluate_stub.cpp)
+endif()
+
+# Add the executable target.
+add_executable(nikolachess ${NIKOLA_SOURCES})
+
+if(NIKOLA_HAS_CUDA)
+    set_target_properties(nikolachess PROPERTIES
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_ARCHITECTURES 70) # Target compute capability 7.0 by default
+endif()
 
 # Include directories so that headers in src/ can be found during
 # compilation.  Having a dedicated include directory would work as
 # well, but keeping headers in src simplifies the project layout for
 # this demonstration.
 target_include_directories(nikolachess PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-
-# Link against standard C++ and CUDA runtime libraries implicitly.
 
 # Optional MPI support for distributed search.  Users can enable
 # NIKOLA_USE_MPI when configuring CMake to compile the distributed
@@ -62,6 +79,7 @@ if(NIKOLA_USE_MPI)
     target_include_directories(nikolachess PRIVATE ${MPI_INCLUDE_PATH})
     target_link_libraries(nikolachess PRIVATE MPI::MPI_CXX)
 endif()
+
 # HPC additions
 set(SRC_HPC
   src/tt_entry.h
@@ -69,5 +87,5 @@ set(SRC_HPC
   src/thread_affinity.cpp
   src/cpu_features.cpp)
 
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
-target_sources(${PROJECT_NAME} PRIVATE ${SRC_HPC})
+set_target_properties(nikolachess PROPERTIES CXX_STANDARD 17)
+target_sources(nikolachess PRIVATE ${SRC_HPC})

--- a/src/cpu_features.cpp
+++ b/src/cpu_features.cpp
@@ -19,7 +19,7 @@ CPUFeatures detect_cpu_features() {
     unsigned int a,b,c,d;
     // Leaf 1 for POPCNT (ECX bit 23) actually POPCNT is SSE4.2? We'll check leaf 1 ECX bit 23 = POPCNT is actually bit 23 for POPCNT in ECX of leaf 1? POPCNT is ECX bit 23.
     __cpuid(1, a,b,c,d);
-    f.popcnt = (ecx & (1u<<23)) != 0; // fix below by defining ecx
+    f.popcnt = (c & (1u<<23)) != 0;
 #endif
     return f;
 }

--- a/src/engine_options.cpp
+++ b/src/engine_options.cpp
@@ -14,6 +14,16 @@ static inline std::string lower(std::string s){
     return s;
 }
 
+static std::string joinTokens(std::vector<std::string>::const_iterator begin,
+                              std::vector<std::string>::const_iterator end) {
+    std::string out;
+    for (auto it = begin; it != end; ++it) {
+        if (!out.empty()) out += " ";
+        out += *it;
+    }
+    return out;
+}
+
 void set_option_from_tokens(const std::vector<std::string>& t) {
     // Expect sequence: setoption name <NAME> [value <VAL>]
     auto itn = std::find(t.begin(), t.end(), "name");
@@ -22,10 +32,10 @@ void set_option_from_tokens(const std::vector<std::string>& t) {
     std::string value;
     auto itv = std::find(t.begin(), t.end(), "value");
     if (itv != t.end()) {
-        name = lower(std::string(itn+1, itv));
-        value = std::string(itv+1, t.end());
+        name = lower(joinTokens(itn + 1, itv));
+        value = joinTokens(itv + 1, t.end());
     } else {
-        name = lower(std::string(itn+1, t.end()));
+        name = lower(joinTokens(itn + 1, t.end()));
         value = "true"; // toggles
     }
 

--- a/src/evaluate_stub.cpp
+++ b/src/evaluate_stub.cpp
@@ -1,0 +1,18 @@
+#include "board.h"
+#include <vector>
+
+namespace nikola {
+
+// CPU fallback implementation of evaluateBoardsGPU. When CUDA is not
+// available this function evaluates each board on the CPU using the
+// existing evaluateBoardCPU helper.
+std::vector<int> evaluateBoardsGPU(const Board* boards, int nBoards) {
+    std::vector<int> scores;
+    scores.reserve(nBoards);
+    for (int i = 0; i < nBoards; ++i) {
+        scores.push_back(evaluateBoardCPU(boards[i]));
+    }
+    return scores;
+}
+
+} // namespace nikola

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -25,6 +25,10 @@
 #include <atomic>
 #include <cstdlib> // for getenv
 #include <vector>
+#include <algorithm>
+#include <unordered_map>
+#include <cstdint>
+#include <random>
 
 // Include tablebase probing functions and piece counting utility.  The
 // engine will consult endgame tablebases when the position has
@@ -217,10 +221,6 @@ static int staticEvaluate(const Board& b) {
 // (draw).  The half‑move clock stored in the Board tracks the
 // number of half moves since the last capture or pawn move; if this
 // reaches 100, the fifty‑move rule applies and the game is drawn.
-
-#include <unordered_map>
-#include <cstdint>
-#include <random>
 
 namespace {
 
@@ -698,15 +698,10 @@ static int minimax(const nikola::Board& board, int depth, int ply, int alpha, in
     // to improve move ordering.  This move should be searched first.
     Move pvMove{};
     bool hasPV = false;
-    // Retrieve the principal variation move from the transposition table.
-    {
-        std::lock_guard<std::mutex> lock(ttMutex);
-        auto itPV = transTable.find(h);
-        if (itPV != transTable.end()) {
-            pvMove = itPV->second.bestMove;
-        }
+    TTEntry pvEntry{};
+    if (tt_lookup(h, pvEntry)) {
+        pvMove = pvEntry.bestMove;
     }
-    // Only consider PV if it has a non‑zero from square (valid move).
     if (!(pvMove.fromRow == 0 && pvMove.fromCol == 0 && pvMove.toRow == 0 && pvMove.toCol == 0)) {
         hasPV = true;
     }
@@ -922,6 +917,8 @@ static int minimax(const nikola::Board& board, int depth, int ply, int alpha, in
     return bestVal;
 }
 
+} // end anonymous namespace
+
 // Choose the best move for the current player using minimax search to a
 // given depth.  Returns the move that yields the highest (for White)
 // or lowest (for Black) evaluation.  If there are no legal moves,
@@ -1010,12 +1007,9 @@ Move findBestMove(const Board& board, int depth, int timeLimitMs) {
         uint64_t rootHash = computeZobrist(board);
         Move pv{};
         bool pvExists = false;
-        {
-            std::lock_guard<std::mutex> lock(ttMutex);
-            auto itPV = transTable.find(rootHash);
-            if (itPV != transTable.end()) {
-                pv = itPV->second.bestMove;
-            }
+        TTEntry rootEntry{};
+        if (tt_lookup(rootHash, rootEntry)) {
+            pv = rootEntry.bestMove;
         }
         if (!(pv.fromRow == 0 && pv.fromCol == 0 && pv.toRow == 0 && pv.toCol == 0)) {
             pvExists = true;

--- a/src/tt_sharded.cpp
+++ b/src/tt_sharded.cpp
@@ -10,6 +10,17 @@ namespace {
 struct Shard {
     std::mutex m;
     std::unordered_map<uint64_t, TTEntry> map;
+    Shard() = default;
+    Shard(const Shard&) = delete;
+    Shard& operator=(const Shard&) = delete;
+    Shard(Shard&& other) noexcept : map(std::move(other.map)) {}
+    Shard& operator=(Shard&& other) noexcept {
+        if (this != &other) {
+            std::lock_guard<std::mutex> lock(other.m);
+            map = std::move(other.map);
+        }
+        return *this;
+    }
 };
 static std::vector<Shard> g_shards;
 static std::atomic<bool> g_inited{false};


### PR DESCRIPTION
## Summary
- Allow building without a CUDA toolkit and provide CPU fallback for GPU evaluation
- Fix option parsing and transposition table sharding
- Clean up CPU feature detection and use new TT in search

## Testing
- `cmake .. && make -j$(nproc)`
- `./nikolachess perft 1`


------
https://chatgpt.com/codex/tasks/task_b_689b8bb865e0832abfdb19c0292c9440