### PR TITLE
Route SyzygyPath option through engine options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,3 +123,11 @@ add_executable(tbprobe_tests
 )
 target_include_directories(tbprobe_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 add_test(NAME tbprobe_tests COMMAND tbprobe_tests)
+
+add_executable(syzygy_path_option_test
+  tests/syzygy_path_option_test.cpp
+  src/engine_options.cpp
+  src/tablebase.cpp
+)
+target_include_directories(syzygy_path_option_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(NAME syzygy_path_option_test COMMAND syzygy_path_option_test)

--- a/src/engine_options.cpp
+++ b/src/engine_options.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <algorithm>
 #include <cctype>
+#include "tablebase.h"
 
 namespace nikola {
 
@@ -50,6 +51,7 @@ void set_option_from_tokens(const std::vector<std::string>& t) {
         G.Strength = v;
     } else if (name == "syzygypath") {
         G.SyzygyPath = value;
+        setTablebasePath(value);
     } else if (name == "uci_showwdl") {
         std::string v = lower(value);
         G.UCI_ShowWDL = (v == "true" || v == "1" || v == "on" || v == "yes");

--- a/src/tablebase.cpp
+++ b/src/tablebase.cpp
@@ -19,6 +19,7 @@ namespace nikola {
 // by a mutex to allow thread‑safe updates and reads.
 static std::string g_tbPath;
 static bool g_tbAvailable = false;
+static int g_tbPathUpdates = 0;
 static std::mutex g_tbMutex;
 
 void setTablebasePath(const std::string& path) {
@@ -30,11 +31,22 @@ void setTablebasePath(const std::string& path) {
     // accordingly.  The Lomonosov 7‑man tablebases, for example,
     // consist of multiple files per configuration.
     g_tbAvailable = !path.empty();
+    ++g_tbPathUpdates;
 }
 
 bool tablebaseAvailable() {
     std::lock_guard<std::mutex> lock(g_tbMutex);
     return g_tbAvailable;
+}
+
+std::string currentTablebasePath() {
+    std::lock_guard<std::mutex> lock(g_tbMutex);
+    return g_tbPath;
+}
+
+int tablebasePathUpdateCount() {
+    std::lock_guard<std::mutex> lock(g_tbMutex);
+    return g_tbPathUpdates;
 }
 
 int probeWDL(const Board& /*board*/) {

--- a/src/tablebase.h
+++ b/src/tablebase.h
@@ -22,6 +22,11 @@ namespace nikola {
 // valid tablebase files.
 void setTablebasePath(const std::string& path);
 
+// For testing purposes, expose the currently configured tablebase path and
+// how many times it has been set.
+std::string currentTablebasePath();
+int tablebasePathUpdateCount();
+
 // Return true if tablebase probing is enabled and at least one
 // tablebase file has been detected.  In this stub implementation
 // this simply returns whether a non‑empty path has been set.

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -272,15 +272,6 @@ void runUciLoop() {
                         use = (c == '1' || c == 't' || c == 'y');
                     }
                     setUseGpu(use);
-                } else if (name == "TablebasePath") {
-                    // Set the path to the directory containing endgame
-                    // tablebases.  When a non‑empty path is provided
-                    // the engine will attempt to probe positions with
-                    // few pieces against the tablebase.  The actual
-                    // probing is implemented in tablebase.cpp; this
-                    // stub will simply record that a path has been
-                    // provided.
-                    nikola::setTablebasePath(value);
                 } else if (name == "PGNFile") {
                     // Set the PGN output file.  If the provided value is
                     // empty, retain the current file path.  This option

--- a/tests/syzygy_path_option_test.cpp
+++ b/tests/syzygy_path_option_test.cpp
@@ -1,0 +1,16 @@
+#include "engine_options.h"
+#include "tablebase.h"
+#include <cassert>
+#include <iostream>
+#include <vector>
+#include <string>
+
+int main() {
+    using namespace nikola;
+    std::vector<std::string> tokens = {"setoption", "name", "SyzygyPath", "value", "/foo/bar"};
+    set_option_from_tokens(tokens);
+    assert(currentTablebasePath() == "/foo/bar");
+    assert(tablebasePathUpdateCount() == 1);
+    std::cout << "syzygy path option test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Centralize `SyzygyPath` handling by letting `set_option_from_tokens` update the tablebase path and call `setTablebasePath`
- Remove redundant `TablebasePath` logic from UCI command parser
- Add unit test verifying `setoption name SyzygyPath` updates probing path exactly once

## Testing
- `cmake --build build --target tbprobe_tests syzygy_path_option_test`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_b_689bac6a7f98832aaf614a449ead32ec