### PR TITLE
Use global piece counter in tablebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,13 +180,8 @@ endif()
 
 # Optional Syzygy path option test (standalone)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/syzygy_path_option_test.cpp")
-  add_executable(syzygy_path_option_test
-    tests/syzygy_path_option_test.cpp
-    src/engine_options.cpp
-    src/tablebase.cpp
-    src/tbprobe.cpp
-    src/fathom_bridge.cpp
-  )
+  add_executable(syzygy_path_option_test tests/syzygy_path_option_test.cpp)
+  target_link_libraries(syzygy_path_option_test nikola_core)
   target_include_directories(syzygy_path_option_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   add_test(NAME syzygy_path_option_test COMMAND syzygy_path_option_test)
 endif()

--- a/src/tablebase.cpp
+++ b/src/tablebase.cpp
@@ -10,6 +10,7 @@
 // position contains a small number of pieces.
 
 #include "tablebase.h"
+#include "board.h"
 #include <mutex>
 #include <string>
 
@@ -27,14 +28,6 @@ static std::string g_tbPath;
 static bool g_tbAvailable = false;
 static int g_tbPathUpdates = 0;
 static std::mutex g_tbMutex;
-
-static int countPiecesLocal(const Board& b) {
-    int count = 0;
-    for (int r = 0; r < 8; ++r)
-        for (int c = 0; c < 8; ++c)
-            if (b.squares[r][c] != EMPTY) ++count;
-    return count;
-}
 
 void setTablebasePath(const std::string& path) {
     std::lock_guard<std::mutex> lock(g_tbMutex);
@@ -66,7 +59,7 @@ int probeWDL(const Board& board) {
         return 2;
     }
     // For now we rely on Fathom which supports up to 7 pieces.
-    if (countPiecesLocal(board) > 7) {
+    if (nikola::countPieces(board) > 7) {
         return 2;
     }
     unsigned res = tbProbeWDL(board);


### PR DESCRIPTION
## Summary
- remove local piece counting helper from tablebase and use `nikola::countPieces`
- link Syzygy path option test against `nikola_core`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_b_689bdd139d88832a918657e287fa1cfc