### PR TITLE
docs: document submodule init and guard fathom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ project(NikolaChess LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Ensure Fathom submodule is initialized
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/fathom/src/tbprobe.c")
+  message(FATAL_ERROR "Missing src/fathom/src/tbprobe.c. Please run 'git submodule update --init --recursive'.")
+endif()
+
 # Try to detect CUDA toolkit if the user asked for CUDA.
 set(NIKOLA_HAS_CUDA FALSE)
 if(NIKOLA_USE_CUDA)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ An experimental, research-friendly chess engine with:
 
 ## Build
 
-You need a C++17 compiler and CMake ≥ 3.12.
+You need a C++17 compiler and CMake ≥ 3.12. After cloning, ensure submodules are initialized:
+
+```sh
+git submodule update --init --recursive
+```
 
 **CPU-only:**
 ```sh


### PR DESCRIPTION
## Summary
- document submodule initialization in the build instructions
- fail CMake configuration clearly when the Fathom submodule is missing

## Testing
- `cmake -S . -B build-test` *(fails: Missing src/fathom/src/tbprobe.c. Please run 'git submodule update --init --recursive'.)*
- `cmake --build build-test` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build-test --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_b_689bdd115758832a9da42fd0048cd638